### PR TITLE
Always try to use passive event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ function MyComponent() {
   // optionally you can pass options, those are default:
   let options = {
     throttle: 100,
-    passive: true,
   }
   let position = useWindowScrollPosition(options)
   // position == { x: 0, y: 0 }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ let getPosition = () => ({
 
 let defaultOptions = {
   throttle: 100,
-  passive: true,
 }
 
 function useWindowScrollPosition(options) {
@@ -36,7 +35,7 @@ function useWindowScrollPosition(options) {
     window.addEventListener(
       'scroll',
       handleScroll,
-      supportsPassive && opts.passive ? { passive: true } : false
+      supportsPassive ? { passive: true } : false
     )
 
     return () => {


### PR DESCRIPTION
From what I understand passive ensures the browser that `event.preventDefault` wont ever be called by the listener. As the consumer of this package has no control over the listener & event there is no point in making this configurable, you know that preventDefault won't get called and thus you should always use passive listener is possible.